### PR TITLE
Fix Issue #8 Endpoint Links Failing

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -8,10 +8,10 @@ SparkPost API enables client applications to integrate with SparkPost and perfor
 JSON is the basis for its request input and response format.
 
 ### SparkPost API Endpoint
-**https://api.sparkpost.com/api/v1**
+**https\://api.sparkpost.com/api/v1**
 
 ### SparkPost Elite API Endpoint
-**https://yourdomain.msyscloud.com/api/v1**
+**https\://yourdomain.msyscloud.com/api/v1**
 
 Note that SparkPost Elite listens on port 443, so no explicit port number is required.
 

--- a/services/introduction.md
+++ b/services/introduction.md
@@ -5,10 +5,10 @@ SparkPost API enables client applications to integrate with SparkPost and perfor
 JSON is the basis for its request input and response format.
 
 ### SparkPost API Endpoint
-**https://api.sparkpost.com/api/v1**
+**https\://api.sparkpost.com/api/v1**
 
 ### SparkPost Elite API Endpoint
-**https://yourdomain.msyscloud.com/api/v1**
+**https\://yourdomain.msyscloud.com/api/v1**
 
 Note that SparkPost Elite listens on port 443, so no explicit port number is required.
 


### PR DESCRIPTION
 - Fixed by escaping auto-URI generator indicated by scheme:// to scheme\://

@CHromek or @jasonrhodes could one of you review so I can merge this. I've added the labels for "Ready to Merge" so you can just update the label if it is good, thanks a bunch.