### PR TITLE
ESCSP-1384

### DIFF
--- a/services/transmissions.md
+++ b/services/transmissions.md
@@ -1027,6 +1027,9 @@ Scheduled transmissions cannot be deleted if the transmission is within 10 minut
 
 ## Delete Transmissions By Campaign [/transmissions?campaign_id={campaign_id}]
 
+<div class="alert alert-info"><strong>Note:</strong> SparkPost Enterprise only, customer-specific configuration option.</div>
+
+
 Delete all transmissions of a campaign by specifying Campaign ID in the URI path. 
 
   + Parameters


### PR DESCRIPTION
Canceling by Campaign ID is a config option only for Gilt and ZipRecruiter.  We can keep the docs public by we need to add a note that it's for Enterprise only.  
Please note: I followed the same Note convention from the Accounts API.  