### PR TITLE
Update suppression-list.md

### DIFF
--- a/services/suppression-list.md
+++ b/services/suppression-list.md
@@ -364,9 +364,9 @@ If the recipient is not in the suppression list, an HTTP status of 404 is return
 
 + Response 204 (application/json; charset=utf-8)
 
-### Insert or Update a List Entry [PUT]
+### Update a List Entry [PUT]
 
-Insert or update a single entry in the suppression list by providing a JSON object. At a minimum, the JSON object should include a suppression type: `transactional` or `non_transactional`. The optional `description` key can be used to include an explanation of what type of message should be suppressed.
+Update a single entry in the suppression list by providing a JSON object. At a minimum, the JSON object should include a suppression type: `transactional` or `non_transactional`. The optional `description` key can be used to include an explanation of what type of message should be suppressed.
 
 If the recipient entry was added to the list by Compliance, it cannot be updated.
 


### PR DESCRIPTION
The documentation currently specifies a method for inserting a recipient address into the suppression list which does not work. Specifically, this request - 

Insert or Update a List Entry

PUT/api/v1/suppression-list/{recipient_email}
URI Parameters
recipient_email	(required)  
Recipient email address

Example: rcpt@example.com
Insert or update a single entry in the suppression list by providing a JSON object. At a minimum, the JSON object should include a suppression type: transactional or non_transactional. The optional description key can be used to include an explanation of what type of message should be suppressed.

If the recipient entry was added to the list by Compliance, it cannot be updated.

Examples

Request
PUT /api/v1/suppression-list/rcpt@example.com

{
  "type": "transactional",
  "description": "Unsubscribe from newsletter"
}

.... does not work. Using a PUT with /api/v1/suppression-list/{recipient_email} will only update a list entry, NOT insert a new one. I have requested an update to the document by deleting the "insert" language. There is a correct PUT insert new entry in the API documentation above where the incorrect one is currently.