### PR TITLE
TR-220 Remove support email address from API (Do Not Merge)

### DIFF
--- a/services/inbound-domains.md
+++ b/services/inbound-domains.md
@@ -78,7 +78,7 @@ Create an inbound domain by providing an **inbound domains object** as the POST 
               "errors" : [
                 {
                   "message" : "Restricted domain",
-                  "description" : "Please contact us at support@sparkpost.com to get this domain authorized for your account.",
+                  "description" : "Please contact SparkPost support to get this domain authorized for your account.",
                   "code" : "7000"
                 }
               ]

--- a/services/tracking-domains.md
+++ b/services/tracking-domains.md
@@ -137,7 +137,7 @@ The detailed status of a tracking domain is described in a JSON object with the 
                 {
                   "code" : "7000",
                   "message" : "restricted domain",
-                  "description" : "Please contact us at support@sparkpost.com to get this domain authorized for your account."
+                  "description" : "Please contact SparkPost support to get this domain authorized for your account."
                 }
               ]
             }


### PR DESCRIPTION
support@sparkpost.com email address and replaced with SparkPost support on inbound and tracking domain pages.